### PR TITLE
CI: Fix install-vim.sh

### DIFF
--- a/scripts/install-vim.sh
+++ b/scripts/install-vim.sh
@@ -19,6 +19,6 @@ case "${TRAVIS_OS_NAME}" in
 		;;
 	*)
 		echo "Unknown value of \${TRAVIS_OS_NAME}: ${TRAVIS_OS_NAME}"
-		return 65
+		exit 65
 		;;
 esac


### PR DESCRIPTION
`return` must not be appeared outside of a function or a sourced script.